### PR TITLE
feat: allow to disable the text field and send icons

### DIFF
--- a/lib/src/models/send_message_configuration.dart
+++ b/lib/src/models/send_message_configuration.dart
@@ -156,6 +156,11 @@ class TextFieldConfiguration {
   /// Default is 1 second.
   final Duration compositionThresholdTime;
 
+  /// Used for enable or disable the text field.
+  /// [false] also will disable the buttons for send images, record audio or take picture.
+  /// Default is [true].
+  final bool enabled;
+
   const TextFieldConfiguration({
     this.contentPadding,
     this.maxLines,
@@ -171,6 +176,7 @@ class TextFieldConfiguration {
     this.compositionThresholdTime = const Duration(seconds: 1),
     this.inputFormatters,
     this.textCapitalization,
+    this.enabled = true,
   });
 }
 

--- a/lib/src/widgets/chatui_textfield.dart
+++ b/lib/src/widgets/chatui_textfield.dart
@@ -193,7 +193,13 @@ class _ChatUITextFieldState extends State<ChatUITextField> {
                           const EdgeInsets.symmetric(horizontal: 6),
                       border: _outLineBorder,
                       focusedBorder: _outLineBorder,
+                      enabled: textFieldConfig?.enabled ?? true,
                       enabledBorder: OutlineInputBorder(
+                        borderSide: const BorderSide(color: Colors.transparent),
+                        borderRadius: textFieldConfig?.borderRadius ??
+                            BorderRadius.circular(textFieldBorderRadius),
+                      ),
+                      disabledBorder: OutlineInputBorder(
                         borderSide: const BorderSide(color: Colors.transparent),
                         borderRadius: textFieldConfig?.borderRadius ??
                             BorderRadius.circular(textFieldBorderRadius),
@@ -223,11 +229,13 @@ class _ChatUITextFieldState extends State<ChatUITextField> {
                               true)
                             IconButton(
                               constraints: const BoxConstraints(),
-                              onPressed: () => _onIconPressed(
-                                ImageSource.camera,
-                                config:
-                                    sendMessageConfig?.imagePickerConfiguration,
-                              ),
+                              onPressed: () => textFieldConfig?.enabled ?? true
+                                  ? _onIconPressed(
+                                      ImageSource.camera,
+                                      config: sendMessageConfig
+                                          ?.imagePickerConfiguration,
+                                    )
+                                  : null,
                               icon: imagePickerIconsConfig
                                       ?.cameraImagePickerIcon ??
                                   Icon(
@@ -240,11 +248,13 @@ class _ChatUITextFieldState extends State<ChatUITextField> {
                               true)
                             IconButton(
                               constraints: const BoxConstraints(),
-                              onPressed: () => _onIconPressed(
-                                ImageSource.gallery,
-                                config:
-                                    sendMessageConfig?.imagePickerConfiguration,
-                              ),
+                              onPressed: () => textFieldConfig?.enabled ?? true
+                                  ? _onIconPressed(
+                                      ImageSource.gallery,
+                                      config: sendMessageConfig
+                                          ?.imagePickerConfiguration,
+                                    )
+                                  : null,
                               icon: imagePickerIconsConfig
                                       ?.galleryImagePickerIcon ??
                                   Icon(
@@ -260,7 +270,9 @@ class _ChatUITextFieldState extends State<ChatUITextField> {
                                 Platform.isAndroid &&
                                 !kIsWeb)
                           IconButton(
-                            onPressed: _recordOrStop,
+                            onPressed: textFieldConfig?.enabled ?? true
+                                ? _recordOrStop
+                                : null,
                             icon: (isRecordingValue
                                     ? voiceRecordingConfig?.micIcon
                                     : voiceRecordingConfig?.stopIcon) ??


### PR DESCRIPTION
For implementing something like a chat bot (for Chat GPT) we need to disable the field to allow the chat to reply to your previous prompt.

# Description
<!--
Provide a description of what this PR is doing.
If you're modifying existing behavior, describe the existing behavior, how this PR is changing it,
and what motivated the change. If this is a breaking change, specify explicitly which APIs were
changed.
-->


## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[ ]`.
-->

- [ ] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [ ] I have followed the [Contributor Guide] when preparing my PR.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [ ] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [ ] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require ChatView users to update their apps following your change?
If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.
### Migration instructions
If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

- [ ] Yes, this PR is a breaking change.
- [ ] No, this PR is not a breaking change.


## Related Issues
<!--
Indicate which issues this PR resolves, if any. For example:
Closes #1234
!-->

<!-- Links -->
[Contributor Guide]: https://github.com/SimformSolutionsPvtLtd/flutter_chatview/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org